### PR TITLE
Add word chain search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Repository Guidelines
+
+All code changes should be accompanied by a test run using:
+
+```bash
+node test.js
+```
+
+The test script must pass before committing.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Word Search
+
+This small browser-based tool searches for a chain of German words. A chain consists of words where each successive word differs from the previous one by exactly one added, removed or changed letter. The dictionary is loaded from `german.dic` on page load.
+
+Open `index.html` in a browser, enter two words and press **Suchen**. If a chain exists it will be printed, otherwise an error message will be shown.
+
+## Tests
+
+A small test script validates the core search algorithm. Run it with:
+
+```bash
+node test.js
+```

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <input type="text" id="field1" placeholder="Eingabe 1">
     <input type="text" id="field2" placeholder="Eingabe 2">
     <button id="searchButton">Suchen</button>
+    <div id="output"></div>
 
     <script src="main.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -1,21 +1,104 @@
 let dictionary = [];
+let dictionarySet = new Set();
+let dictionaryByLength = {};
 
 // Laden des Wörterbuchs aus der Datei german.dic
 fetch('german.dic')
     .then(response => response.text())
     .then(text => {
         dictionary = text.split(/\r?\n/).filter(Boolean);
+        dictionarySet = new Set(dictionary);
+        dictionaryByLength = {};
+        dictionary.forEach(word => {
+            const len = word.length;
+            if (!dictionaryByLength[len]) {
+                dictionaryByLength[len] = [];
+            }
+            dictionaryByLength[len].push(word);
+        });
         console.log('Wörterbuch geladen, Anzahl Wörter:', dictionary.length);
     })
     .catch(err => console.error('Fehler beim Laden des Wörterbuchs:', err));
 
+const output = document.getElementById('output');
+
+function isOneEditApart(a, b) {
+    if (Math.abs(a.length - b.length) > 1) return false;
+    if (a.length === b.length) {
+        let diff = 0;
+        for (let i = 0; i < a.length; i++) {
+            if (a[i] !== b[i]) {
+                diff++;
+                if (diff > 1) return false;
+            }
+        }
+        return diff === 1;
+    }
+
+    // ensure a is the shorter
+    if (a.length > b.length) [a, b] = [b, a];
+    let i = 0, j = 0, diff = 0;
+    while (i < a.length && j < b.length) {
+        if (a[i] === b[j]) {
+            i++; j++;
+        } else {
+            diff++; j++;
+            if (diff > 1) return false;
+        }
+    }
+    return true;
+}
+
+function getNeighbors(word, visited) {
+    const res = [];
+    const len = word.length;
+    [len - 1, len, len + 1].forEach(l => {
+        const list = dictionaryByLength[l] || [];
+        for (const cand of list) {
+            if (!visited.has(cand) && isOneEditApart(word, cand)) {
+                res.push(cand);
+            }
+        }
+    });
+    return res;
+}
+
+function findChain(start, target) {
+    if (start === target) return [start];
+    const queue = [[start]];
+    const visited = new Set([start]);
+
+    while (queue.length > 0) {
+        const path = queue.shift();
+        const word = path[path.length - 1];
+        const neighbors = getNeighbors(word, visited);
+        for (const n of neighbors) {
+            if (visited.has(n)) continue;
+            const newPath = path.concat(n);
+            if (n === target) return newPath;
+            visited.add(n);
+            queue.push(newPath);
+        }
+    }
+    return null;
+}
+
 document.getElementById('searchButton').addEventListener('click', function() {
-    const value1 = document.getElementById('field1').value;
-    const value2 = document.getElementById('field2').value;
+    const value1 = document.getElementById('field1').value.trim();
+    const value2 = document.getElementById('field2').value.trim();
 
-    const found1 = dictionary.includes(value1);
-    const found2 = dictionary.includes(value2);
+    if (!dictionarySet.has(value1) || !dictionarySet.has(value2)) {
+        output.textContent = "Eines der Wörter wurde nicht im Wörterbuch gefunden.";
+        return;
+    }
 
-    console.log('Suche nach:', value1, value2);
-    console.log('Gefunden?', found1, found2);
+    output.textContent = "Suche läuft...";
+    setTimeout(() => {
+        const chain = findChain(value1, value2);
+        if (chain) {
+            output.textContent = chain.join(' -> ');
+        } else {
+            output.textContent = 'Keine Wortkette gefunden.';
+        }
+    }, 50);
 });

--- a/styles.css
+++ b/styles.css
@@ -6,3 +6,8 @@ body {
 input {
     margin-right: 10px;
 }
+
+#output {
+    margin-top: 20px;
+    white-space: pre-wrap;
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const {
+    preprocessDictionary,
+    isOneEditApart,
+    findChain
+} = require('./wordchain');
+
+const words = ['cat', 'cot', 'cog', 'dog'];
+const { dictionaryByLength } = preprocessDictionary(words);
+
+assert.strictEqual(isOneEditApart('cat', 'cot'), true);
+assert.strictEqual(isOneEditApart('cat', 'dog'), false);
+
+const chain = findChain('cat', 'dog', dictionaryByLength);
+assert.deepStrictEqual(chain, ['cat', 'cot', 'cog', 'dog']);
+
+const chain2 = findChain('cat', 'bat', dictionaryByLength);
+assert.strictEqual(chain2, null);
+
+console.log('All tests passed.');

--- a/wordchain.js
+++ b/wordchain.js
@@ -1,0 +1,80 @@
+function preprocessDictionary(words) {
+    const dictionarySet = new Set(words);
+    const dictionaryByLength = {};
+    words.forEach(word => {
+        const len = word.length;
+        if (!dictionaryByLength[len]) {
+            dictionaryByLength[len] = [];
+        }
+        dictionaryByLength[len].push(word);
+    });
+    return { dictionarySet, dictionaryByLength };
+}
+
+function isOneEditApart(a, b) {
+    if (Math.abs(a.length - b.length) > 1) return false;
+    if (a.length === b.length) {
+        let diff = 0;
+        for (let i = 0; i < a.length; i++) {
+            if (a[i] !== b[i]) {
+                diff++;
+                if (diff > 1) return false;
+            }
+        }
+        return diff === 1;
+    }
+    if (a.length > b.length) [a, b] = [b, a];
+    let i = 0, j = 0, diff = 0;
+    while (i < a.length && j < b.length) {
+        if (a[i] === b[j]) {
+            i++; j++;
+        } else {
+            diff++; j++;
+            if (diff > 1) return false;
+        }
+    }
+    return true;
+}
+
+function getNeighbors(word, dictByLength, visited) {
+    const res = [];
+    const len = word.length;
+    [len - 1, len, len + 1].forEach(l => {
+        const list = dictByLength[l] || [];
+        for (const cand of list) {
+            if (!visited.has(cand) && isOneEditApart(word, cand)) {
+                res.push(cand);
+            }
+        }
+    });
+    return res;
+}
+
+function findChain(start, target, dictByLength) {
+    if (start === target) return [start];
+    const queue = [[start]];
+    const visited = new Set([start]);
+
+    while (queue.length > 0) {
+        const path = queue.shift();
+        const word = path[path.length - 1];
+        const neighbors = getNeighbors(word, dictByLength, visited);
+        for (const n of neighbors) {
+            if (visited.has(n)) continue;
+            const newPath = path.concat(n);
+            if (n === target) return newPath;
+            visited.add(n);
+            queue.push(newPath);
+        }
+    }
+    return null;
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = {
+        preprocessDictionary,
+        isOneEditApart,
+        getNeighbors,
+        findChain
+    };
+}


### PR DESCRIPTION
## Summary
- add output element to show results
- implement dictionary preprocessing and BFS search for word chains
- display result or error message after search
- style output area
- add docs and repository guidelines
- provide basic node test

## Testing
- `node test.js`


------
https://chatgpt.com/codex/tasks/task_e_6856c390ebf4832a9c25f1ae2820d7de