### PR TITLE
Restrict edits to approach target length

### DIFF
--- a/test.js
+++ b/test.js
@@ -17,4 +17,20 @@ assert.deepStrictEqual(chain, ['cat', 'cot', 'cog', 'dog']);
 const chain2 = findChain('cat', 'bat', dictionaryByLength);
 assert.strictEqual(chain2, null);
 
+// additional tests for length restrictions
+const words2 = ['a', 'ab', 'ba'];
+const { dictionaryByLength: dict2 } = preprocessDictionary(words2);
+const chain3 = findChain('a', 'ba', dict2);
+assert.deepStrictEqual(chain3, ['a', 'ba']);
+
+const words3 = ['ab', 'a', 'b'];
+const { dictionaryByLength: dict3 } = preprocessDictionary(words3);
+const chain4 = findChain('ab', 'b', dict3);
+assert.deepStrictEqual(chain4, ['ab', 'b']);
+
+const words4 = ['ab', 'a', 'ca', 'cd'];
+const { dictionaryByLength: dict4 } = preprocessDictionary(words4);
+const chain5 = findChain('ab', 'cd', dict4);
+assert.strictEqual(chain5, null);
+
 console.log('All tests passed.');

--- a/wordchain.js
+++ b/wordchain.js
@@ -52,6 +52,8 @@ function getNeighbors(word, dictByLength, visited) {
 
 function findChain(start, target, dictByLength) {
     if (start === target) return [start];
+    const startLen = start.length;
+    const targetLen = target.length;
     const queue = [[start]];
     const visited = new Set([start]);
 
@@ -61,6 +63,16 @@ function findChain(start, target, dictByLength) {
         const neighbors = getNeighbors(word, dictByLength, visited);
         for (const n of neighbors) {
             if (visited.has(n)) continue;
+            const nLen = n.length;
+
+            if (startLen < targetLen) {
+                if (nLen < word.length || nLen > targetLen) continue;
+            } else if (startLen > targetLen) {
+                if (nLen > word.length || nLen < targetLen) continue;
+            } else {
+                if (nLen !== word.length) continue;
+            }
+
             const newPath = path.concat(n);
             if (n === target) return newPath;
             visited.add(n);


### PR DESCRIPTION
## Summary
- only allow adding or removing letters when moving toward the target length
- extend unit tests for the new restriction

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_685823947170832a9de87d11c5e619fd