### PR TITLE
Normalize dictionary and input case

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,7 +6,9 @@ let dictionaryByLength = {};
 fetch('german.dic')
     .then(response => response.text())
     .then(text => {
-        dictionary = text.split(/\r?\n/).filter(Boolean);
+        dictionary = text.split(/\r?\n/)
+            .filter(Boolean)
+            .map(word => word.toLowerCase());
         const processed = preprocessDictionary(dictionary);
         dictionarySet = processed.dictionarySet;
         dictionaryByLength = processed.dictionaryByLength;
@@ -16,8 +18,8 @@ fetch('german.dic')
 
 const output = document.getElementById('output');
 
-    const value1 = document.getElementById('field1').value.trim();
-    const value2 = document.getElementById('field2').value.trim();
+    const value1 = document.getElementById('field1').value.trim().toLowerCase();
+    const value2 = document.getElementById('field2').value.trim().toLowerCase();
 
     if (!dictionarySet.has(value1) || !dictionarySet.has(value2)) {
         output.textContent = "Eines der Wörter wurde nicht im Wörterbuch gefunden.";

--- a/test.js
+++ b/test.js
@@ -33,4 +33,10 @@ const { dictionaryByLength: dict4 } = preprocessDictionary(words4);
 const chain5 = findChain('ab', 'cd', dict4);
 assert.strictEqual(chain5, null);
 
+// ensure dictionary words are normalized to lowercase
+const mixedWords = ['Cat', 'cot', 'cog', 'Dog'];
+const { dictionaryByLength: mixedDict } = preprocessDictionary(mixedWords);
+const chain6 = findChain('cat', 'dog', mixedDict);
+assert.deepStrictEqual(chain6, ['cat', 'cot', 'cog', 'dog']);
+
 console.log('All tests passed.');

--- a/wordchain.js
+++ b/wordchain.js
@@ -1,7 +1,10 @@
 function preprocessDictionary(words) {
-    const dictionarySet = new Set(words);
+    // Convert all dictionary entries to lowercase to allow case-insensitive
+    // lookups.
+    const normalized = words.map(w => w.toLowerCase());
+    const dictionarySet = new Set(normalized);
     const dictionaryByLength = {};
-    words.forEach(word => {
+    normalized.forEach(word => {
         const len = word.length;
         if (!dictionaryByLength[len]) {
             dictionaryByLength[len] = [];


### PR DESCRIPTION
## Summary
- normalize all words in dictionary to lowercase
- convert user input to lowercase before searching
- test that dictionary casing is normalized

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_685824cde7a8832a98b29f0caa6d28af