### PR TITLE
Fix syntax error by reinstating performSearch

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,6 +18,8 @@ fetch('german.dic')
 
 const output = document.getElementById('output');
 
+function performSearch() {
+
     const value1 = document.getElementById('field1').value.trim().toLowerCase();
     const value2 = document.getElementById('field2').value.trim().toLowerCase();
 


### PR DESCRIPTION
## Summary
- add missing `performSearch` function wrapper in `main.js`

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_685826ac9d90832aad42519a2461bf9d