### PR TITLE
Load dictionary before search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Word Search
 
-This small browser-based tool searches for a chain of German words. A chain consists of words where each successive word differs from the previous one by exactly one added, removed or changed letter. The dictionary is loaded from `german.dic` on page load.
+This small browser-based tool searches for a chain of German words. A chain consists of words where each successive word differs from the previous one by exactly one added, removed or changed letter. The dictionary is loaded from `german.dic` on page load and the search button stays disabled until the load finished.
 
 Open `index.html` in a browser, enter two words and press **Suchen**. If a chain exists it will be printed, otherwise an error message will be shown.
 
@@ -15,14 +15,14 @@ node test.js
 ## Project Structure
 
 - `index.html` – Main HTML page with two input fields and a search button.
-- `main.js` – JavaScript that loads `german.dic` and performs a lookup when the button is pressed.
+- `main.js` – JavaScript that loads `german.dic`, enables the search button once loading finished and performs a lookup when the button is pressed.
 - `styles.css` – Basic styling for the page.
 - `german.dic` – Dictionary file containing German words, one per line.
 - `hello.txt` – Simple text file used as an example.
 
 ## Usage
 
-1. Open `index.html` in a modern browser. The page will load `german.dic` and allow you to check whether the given words exist in the dictionary.
+1. Open `index.html` in a modern browser. The page loads `german.dic` automatically; the search button becomes clickable once the dictionary is ready.
 2. Alternatively, you can start a simple web server and navigate to `index.html`:
    ```bash
    python3 -m http.server

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <form id="searchForm">
         <input type="text" id="field1" placeholder="Eingabe 1">
         <input type="text" id="field2" placeholder="Eingabe 2">
-        <button id="searchButton" type="submit">Suchen</button>
+        <button id="searchButton" type="submit" disabled>Suchen</button>
     </form>
     <div id="output"></div>
 

--- a/test.js
+++ b/test.js
@@ -4,39 +4,47 @@ const {
     isOneEditApart,
     findChain
 } = require('./wordchain');
+const { loadDictionary, getDictionary } = require('./main');
 
-const words = ['cat', 'cot', 'cog', 'dog'];
-const { dictionaryByLength } = preprocessDictionary(words);
+async function run() {
+    const words = ['cat', 'cot', 'cog', 'dog'];
+    const { dictionaryByLength } = preprocessDictionary(words);
 
-assert.strictEqual(isOneEditApart('cat', 'cot'), true);
-assert.strictEqual(isOneEditApart('cat', 'dog'), false);
+    assert.strictEqual(isOneEditApart('cat', 'cot'), true);
+    assert.strictEqual(isOneEditApart('cat', 'dog'), false);
 
-const chain = findChain('cat', 'dog', dictionaryByLength);
-assert.deepStrictEqual(chain, ['cat', 'cot', 'cog', 'dog']);
+    const chain = findChain('cat', 'dog', dictionaryByLength);
+    assert.deepStrictEqual(chain, ['cat', 'cot', 'cog', 'dog']);
 
-const chain2 = findChain('cat', 'bat', dictionaryByLength);
-assert.strictEqual(chain2, null);
+    const chain2 = findChain('cat', 'bat', dictionaryByLength);
+    assert.strictEqual(chain2, null);
 
-// additional tests for length restrictions
-const words2 = ['a', 'ab', 'ba'];
-const { dictionaryByLength: dict2 } = preprocessDictionary(words2);
-const chain3 = findChain('a', 'ba', dict2);
-assert.deepStrictEqual(chain3, ['a', 'ba']);
+    // additional tests for length restrictions
+    const words2 = ['a', 'ab', 'ba'];
+    const { dictionaryByLength: dict2 } = preprocessDictionary(words2);
+    const chain3 = findChain('a', 'ba', dict2);
+    assert.deepStrictEqual(chain3, ['a', 'ba']);
 
-const words3 = ['ab', 'a', 'b'];
-const { dictionaryByLength: dict3 } = preprocessDictionary(words3);
-const chain4 = findChain('ab', 'b', dict3);
-assert.deepStrictEqual(chain4, ['ab', 'b']);
+    const words3 = ['ab', 'a', 'b'];
+    const { dictionaryByLength: dict3 } = preprocessDictionary(words3);
+    const chain4 = findChain('ab', 'b', dict3);
+    assert.deepStrictEqual(chain4, ['ab', 'b']);
 
-const words4 = ['ab', 'a', 'ca', 'cd'];
-const { dictionaryByLength: dict4 } = preprocessDictionary(words4);
-const chain5 = findChain('ab', 'cd', dict4);
-assert.strictEqual(chain5, null);
+    const words4 = ['ab', 'a', 'ca', 'cd'];
+    const { dictionaryByLength: dict4 } = preprocessDictionary(words4);
+    const chain5 = findChain('ab', 'cd', dict4);
+    assert.strictEqual(chain5, null);
 
-// ensure dictionary words are normalized to lowercase
-const mixedWords = ['Cat', 'cot', 'cog', 'Dog'];
-const { dictionaryByLength: mixedDict } = preprocessDictionary(mixedWords);
-const chain6 = findChain('cat', 'dog', mixedDict);
-assert.deepStrictEqual(chain6, ['cat', 'cot', 'cog', 'dog']);
+    // ensure dictionary words are normalized to lowercase
+    const mixedWords = ['Cat', 'cot', 'cog', 'Dog'];
+    const { dictionaryByLength: mixedDict } = preprocessDictionary(mixedWords);
+    const chain6 = findChain('cat', 'dog', mixedDict);
+    assert.deepStrictEqual(chain6, ['cat', 'cot', 'cog', 'dog']);
 
-console.log('All tests passed.');
+    await loadDictionary('german.dic');
+    assert.ok(getDictionary().length > 0);
+
+    console.log('All tests passed.');
+}
+
+run();


### PR DESCRIPTION
## Summary
- disable the search button until the dictionary is loaded
- export and reuse dictionary loader for tests
- document new behaviour
- expand tests to cover dictionary loading

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_6858276a03bc832a8110cf8f8c0ca80b