### PR TITLE
Improve chain output styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This small browser-based tool searches for a chain of German words. A chain consists of words where each successive word differs from the previous one by exactly one added, removed or changed letter. The dictionary is loaded from `german.dic` on page load and the search button stays disabled until the load finished.
 
-Open `index.html` in a browser, enter two words and press **Suchen**. If a chain exists it will be printed, otherwise an error message will be shown.
+Open `index.html` in a browser, enter two words and press **Suchen**. If a chain exists it will be printed as a small ordered list, otherwise an error message will be shown.
 
 ## Tests
 

--- a/main.js
+++ b/main.js
@@ -26,6 +26,10 @@ async function loadDictionary(path = 'german.dic') {
 }
 let output;
 
+function formatChainHTML(chain) {
+    return '<ol class="chain">' + chain.map(w => `<li>${w}</li>`).join('') + '</ol>';
+}
+
 function performSearch() {
     const value1 = document.getElementById('field1').value.trim().toLowerCase();
     const value2 = document.getElementById('field2').value.trim().toLowerCase();
@@ -39,7 +43,7 @@ function performSearch() {
     setTimeout(() => {
         const chain = findChain(value1, value2, dictionaryByLength);
         if (chain) {
-            output.textContent = chain.join(' -> ');
+            output.innerHTML = formatChainHTML(chain);
         } else {
             output.textContent = 'Keine Wortkette gefunden.';
         }
@@ -71,6 +75,7 @@ if (typeof module !== 'undefined') {
     module.exports = {
         loadDictionary,
         getDictionary: () => dictionary,
-        isDictionaryLoaded: () => dictionaryLoaded
+        isDictionaryLoaded: () => dictionaryLoaded,
+        formatChainHTML
     };
 }

--- a/styles.css
+++ b/styles.css
@@ -48,3 +48,7 @@ input {
     white-space: pre-wrap;
     text-align: left;
 }
+
+#output ol {
+    padding-left: 20px;
+}

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ const {
     isOneEditApart,
     findChain
 } = require('./wordchain');
-const { loadDictionary, getDictionary } = require('./main');
+const { loadDictionary, getDictionary, formatChainHTML } = require('./main');
 
 async function run() {
     const words = ['cat', 'cot', 'cog', 'dog'];
@@ -34,6 +34,10 @@ async function run() {
     const { dictionaryByLength: dict4 } = preprocessDictionary(words4);
     const chain5 = findChain('ab', 'cd', dict4);
     assert.strictEqual(chain5, null);
+
+    // test HTML formatting
+    const html = formatChainHTML(['a', 'b']);
+    assert.strictEqual(html, '<ol class="chain"><li>a</li><li>b</li></ol>');
 
     // ensure dictionary words are normalized to lowercase
     const mixedWords = ['Cat', 'cot', 'cog', 'Dog'];


### PR DESCRIPTION
## Summary
- display found word chains as an ordered list
- expose helper `formatChainHTML`
- style `#output ol` with padding
- document new behaviour
- test HTML formatting

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_685829b51ba8832aa97ac25019be3322