### PR TITLE
Add visual diff for wordchain steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This small browser-based tool searches for a chain of German words. A chain cons
 
 A simple favicon with a "W" helps identify the page in the browser tab.
 
-Open `index.html` in a browser, enter two words and press **Suchen**. If a chain exists it will be printed as a small ordered list, otherwise an error message will be shown.
+Open `index.html` in a browser, enter two words and press **Suchen**. If a chain exists it will be printed as a small ordered list. The letter that changes from one word to the next is highlighted with a subtle background color. If no chain is found an error message will be shown.
 
 ## Tests
 

--- a/main.js
+++ b/main.js
@@ -26,8 +26,28 @@ async function loadDictionary(path = 'german.dic') {
 }
 let output;
 
+function highlightChange(prev, curr) {
+    let i = 0, j = 0;
+    while (i < prev.length && j < curr.length && prev[i] === curr[j]) {
+        i++; j++;
+    }
+    if (j < curr.length) {
+        return curr.slice(0, j) + '<span class="diff">' + curr[j] + '</span>' + curr.slice(j + 1);
+    }
+    return curr;
+}
+
 function formatChainHTML(chain) {
-    return '<ol class="chain">' + chain.map(w => `<li>${w}</li>`).join('') + '</ol>';
+    const items = [];
+    for (let i = 0; i < chain.length; i++) {
+        const word = chain[i];
+        if (i === 0) {
+            items.push(`<li>${word}</li>`);
+        } else {
+            items.push(`<li>${highlightChange(chain[i - 1], word)}</li>`);
+        }
+    }
+    return '<ol class="chain">' + items.join('') + '</ol>';
 }
 
 function performSearch() {
@@ -76,6 +96,7 @@ if (typeof module !== 'undefined') {
         loadDictionary,
         getDictionary: () => dictionary,
         isDictionaryLoaded: () => dictionaryLoaded,
-        formatChainHTML
+        formatChainHTML,
+        highlightChange
     };
 }

--- a/styles.css
+++ b/styles.css
@@ -52,3 +52,7 @@ input {
 #output ol {
     padding-left: 20px;
 }
+
+.diff {
+    background-color: #fffbcc;
+}

--- a/test.js
+++ b/test.js
@@ -37,7 +37,7 @@ async function run() {
 
     // test HTML formatting
     const html = formatChainHTML(['a', 'b']);
-    assert.strictEqual(html, '<ol class="chain"><li>a</li><li>b</li></ol>');
+    assert.strictEqual(html, '<ol class="chain"><li>a</li><li><span class="diff">b</span></li></ol>');
 
     // ensure dictionary words are normalized to lowercase
     const mixedWords = ['Cat', 'cot', 'cog', 'Dog'];


### PR DESCRIPTION
## Summary
- highlight the letter that changes from word to word
- style diff letters with a light background color
- document the new visual hint feature in README
- adjust HTML formatting test to match new output

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_68582bf38e20832a8299192cddd2df86