### PR TITLE
Switch neighbor lookup to dictionary scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Word Search
 
-This small browser-based tool searches for a chain of German words. A chain consists of words where each successive word differs from the previous one by exactly one added, removed or changed letter. The dictionary is loaded from `german.dic` on page load and the search button stays disabled until the load finished.
+This small browser-based tool searches for a chain of German words. A chain consists of words where each successive word differs from the previous one by exactly one added, removed or changed letter. The dictionary is loaded from `german.dic` on page load and the search button stays disabled until the load finished. The algorithm now checks candidate neighbors directly against the dictionary instead of generating all possible letter combinations.
 
 A simple favicon with a "W" helps identify the page in the browser tab.
 

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const {
     preprocessDictionary,
     isOneEditApart,
+    getNeighborsFromDictionary,
     findChain
 } = require('./wordchain');
 const { loadDictionary, getDictionary, formatChainHTML } = require('./main');
@@ -12,6 +13,9 @@ async function run() {
 
     assert.strictEqual(isOneEditApart('cat', 'cot'), true);
     assert.strictEqual(isOneEditApart('cat', 'dog'), false);
+
+    const neighbors = getNeighborsFromDictionary('cat', dictionaryByLength, new Set(['cat']));
+    assert.deepStrictEqual(neighbors.sort(), ['cot']);
 
     const chain = findChain('cat', 'dog', dictionaryByLength, dictionarySet);
     assert.deepStrictEqual(chain, ['cat', 'cot', 'cog', 'dog']);

--- a/wordchain.js
+++ b/wordchain.js
@@ -39,42 +39,23 @@ function isOneEditApart(a, b) {
     return true;
 }
 
-const ALPHABET = 'abcdefghijklmnopqrstuvwxyzäöüß';
 
-function getNeighbors(word, dictionarySet, visited) {
-    const neighbors = new Set();
+function getNeighborsFromDictionary(word, dictionaryByLength, visited) {
+    const result = [];
     const len = word.length;
-
-    // substitution
-    for (let i = 0; i < len; i++) {
-        for (const ch of ALPHABET) {
-            if (ch === word[i]) continue;
-            const cand = word.slice(0, i) + ch + word.slice(i + 1);
-            if (!visited.has(cand) && dictionarySet.has(cand)) {
-                neighbors.add(cand);
+    const lengths = [len];
+    if (dictionaryByLength[len + 1]) lengths.push(len + 1);
+    if (len > 1 && dictionaryByLength[len - 1]) lengths.push(len - 1);
+    for (const l of lengths) {
+        const words = dictionaryByLength[l] || [];
+        for (const candidate of words) {
+            if (visited.has(candidate) || candidate === word) continue;
+            if (isOneEditApart(word, candidate)) {
+                result.push(candidate);
             }
         }
     }
-
-    // deletion
-    for (let i = 0; i < len; i++) {
-        const cand = word.slice(0, i) + word.slice(i + 1);
-        if (!visited.has(cand) && dictionarySet.has(cand)) {
-            neighbors.add(cand);
-        }
-    }
-
-    // insertion
-    for (let i = 0; i <= len; i++) {
-        for (const ch of ALPHABET) {
-            const cand = word.slice(0, i) + ch + word.slice(i);
-            if (!visited.has(cand) && dictionarySet.has(cand)) {
-                neighbors.add(cand);
-            }
-        }
-    }
-
-    return Array.from(neighbors);
+    return result;
 }
 
 function findChain(start, target, dictByLength, dictionarySet) {
@@ -87,7 +68,7 @@ function findChain(start, target, dictByLength, dictionarySet) {
     while (queue.length > 0) {
         const path = queue.shift();
         const word = path[path.length - 1];
-        const neighbors = getNeighbors(word, dictionarySet, visited);
+        const neighbors = getNeighborsFromDictionary(word, dictByLength, visited);
         for (const n of neighbors) {
             if (visited.has(n)) continue;
             const nLen = n.length;
@@ -113,7 +94,7 @@ if (typeof module !== 'undefined') {
     module.exports = {
         preprocessDictionary,
         isOneEditApart,
-        getNeighbors,
+        getNeighborsFromDictionary,
         findChain
     };
 }


### PR DESCRIPTION
## Summary
- scan dictionary entries to find neighbors instead of generating words
- export new `getNeighborsFromDictionary`
- add tests for new helper
- document algorithm change in README
- remove the old neighbor generation function

## Testing
- `node test.js`


------
https://chatgpt.com/codex/tasks/task_e_6858300c39c8832ab8d1091e979c7c73